### PR TITLE
Remove output field from internal `workspaces` field

### DIFF
--- a/display-servers/xlib-display-server/src/lib.rs
+++ b/display-servers/xlib-display-server/src/lib.rs
@@ -155,7 +155,7 @@ impl XlibDisplayServer {
                         if wsc.relative.unwrap_or(false) {
                             screen.bbox.add(output_match.bbox);
                         }
-                        screen.id = i + 1;
+                        screen.id = Some(i + 1);
                     }
                     None => continue,
                 }
@@ -181,7 +181,7 @@ impl XlibDisplayServer {
                     .filter(|screen| !workspaces.iter().any(|wsc| wsc.output == screen.output))
                     .for_each(|screen| {
                         let mut s = screen.clone();
-                        s.id = next_id;
+                        s.id = Some(next_id);
                         next_id += 1;
                         events.push(DisplayEvent::ScreenCreate(s));
                     });

--- a/display-servers/xlib-display-server/src/lib.rs
+++ b/display-servers/xlib-display-server/src/lib.rs
@@ -149,6 +149,7 @@ impl XlibDisplayServer {
             for (i, wsc) in workspaces.iter().enumerate() {
                 let mut screen = Screen::from(wsc);
                 screen.root = self.root.into();
+                // If there is a screen corresponding to the given output, create the workspace
                 match screens.iter().find(|i| i.output == wsc.output) {
                     Some(output_match) => {
                         if wsc.relative.unwrap_or(false) {

--- a/display-servers/xlib-display-server/src/lib.rs
+++ b/display-servers/xlib-display-server/src/lib.rs
@@ -155,7 +155,7 @@ impl XlibDisplayServer {
                         if wsc.relative.unwrap_or(false) {
                             screen.bbox.add(output_match.bbox);
                         }
-                        screen.id = Some(i + 1);
+                        screen.id = i + 1;
                     }
                     None => continue,
                 }
@@ -181,7 +181,7 @@ impl XlibDisplayServer {
                     .filter(|screen| !workspaces.iter().any(|wsc| wsc.output == screen.output))
                     .for_each(|screen| {
                         let mut s = screen.clone();
-                        s.id = Some(next_id);
+                        s.id = next_id;
                         next_id += 1;
                         events.push(DisplayEvent::ScreenCreate(s));
                     });

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -100,10 +100,10 @@ impl State {
 
     /// Focuses the workspace containing a given point.
     pub fn focus_workspace_with_point(&mut self, x: i32, y: i32) {
-        let focused_id = match self.focus_manager.workspace(&self.workspaces) {
-            Some(ws) => ws.id,
-            None => return,
+        let Some(focused_id) = self.focus_manager.workspace(&self.workspaces).map(|ws| ws.id) else {
+            return;
         };
+
         if let Some(ws) = self
             .workspaces
             .iter()

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -24,14 +24,13 @@ impl State {
         };
 
         // Make sure the focused window's workspace is focused.
-        if let Some(workspace) = self.workspaces.iter().find(|ws| ws.is_displaying(&window)) {
-            // this is an uggly workaround to suffice some CI failure related to https://github.com/rust-lang/rust/issues/59159
-            let workspace_output_borrow_checker_workaround = workspace.output.clone();
-            let workspace_id_borrow_checker_workaround = workspace.id;
-            _ = self.focus_workspace_work(
-                &workspace_output_borrow_checker_workaround,
-                workspace_id_borrow_checker_workaround,
-            );
+        if let Some(workspace_id) = self
+            .workspaces
+            .iter()
+            .find(|ws| ws.is_displaying(&window))
+            .map(|ws| ws.id)
+        {
+            let _ = self.focus_workspace_work(workspace_id);
         }
 
         // Make sure the focused window's tag is focused.
@@ -43,7 +42,7 @@ impl State {
     /// Focuses the given workspace.
     // NOTE: Should only be called externally from this file.
     pub fn focus_workspace(&mut self, workspace: &Workspace) {
-        if self.focus_workspace_work(&workspace.output, workspace.id) {
+        if self.focus_workspace_work(workspace.id) {
             // Make sure this workspaces tag is focused.
             workspace.tag.iter().for_each(|t| {
                 self.focus_tag_work(*t);
@@ -71,7 +70,7 @@ impl State {
             .cloned()
             .collect();
         for ws in &to_focus {
-            self.focus_workspace_work(&ws.output, ws.id);
+            self.focus_workspace_work(ws.id);
         }
         // Make sure the focused window is on this workspace.
         if self.focus_manager.behaviour.is_sloppy() && self.focus_manager.sloppy_mouse_follows_focus
@@ -101,16 +100,14 @@ impl State {
 
     /// Focuses the workspace containing a given point.
     pub fn focus_workspace_with_point(&mut self, x: i32, y: i32) {
-        let Some(focused_ws) = self.focus_manager.workspace(&self.workspaces) else {
-            return
+        let focused_id = match self.focus_manager.workspace(&self.workspaces) {
+            Some(ws) => ws.id,
+            None => return,
         };
         if let Some(ws) = self
             .workspaces
             .iter()
-            .find(|ws| {
-                ws.contains_point(x, y)
-                    && !(ws.output == focused_ws.output && ws.id == focused_ws.id)
-            })
+            .find(|ws| ws.contains_point(x, y) && ws.id != focused_id)
             .cloned()
         {
             self.focus_workspace(&ws);
@@ -226,21 +223,17 @@ impl State {
         Some(found.clone())
     }
 
-    fn focus_workspace_work(&mut self, output: &str, id: usize) -> bool {
+    fn focus_workspace_work(&mut self, ws_id: usize) -> bool {
         //no new history if no change
         if let Some(fws) = self.focus_manager.workspace(&self.workspaces) {
-            if fws.output == output && fws.id == id {
+            if fws.id == ws_id {
                 return false;
             }
         }
         // Clean old history.
         self.focus_manager.workspace_history.truncate(10);
         // Add this focus to the history.
-        if let Some(index) = self
-            .workspaces
-            .iter()
-            .position(|x| x.output == output && x.id == id)
-        {
+        if let Some(index) = self.workspaces.iter().position(|x| x.id == ws_id) {
             self.focus_manager.workspace_history.push_front(index);
             return true;
         }
@@ -421,7 +414,7 @@ mod tests {
             .focus_manager
             .workspace(&manager.state.workspaces)
             .unwrap();
-        assert_eq!(actual.output, String::new());
+        assert_eq!(actual.id, 1);
     }
 
     #[test]

--- a/leftwm-core/src/handlers/screen_create_handler.rs
+++ b/leftwm-core/src/handlers/screen_create_handler.rs
@@ -11,9 +11,15 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
 
         let tag_index = self.state.workspaces.len();
         let tag_len = self.state.tags.len_normal();
-        let workspace_id = screen
-            .id
-            .unwrap_or_else(|| self.state.workspaces.last().map_or(0, |ws| ws.id) + 1);
+
+        // Only used in tests, where there are multiple screens being created by `Screen::default()` (id is 0 by default)
+        #[cfg(test)]
+        let workspace_id = match screen.id {
+            0 => self.state.workspaces.last().map_or(0, |ws| ws.id) + 1,
+            other => other,
+        };
+        #[cfg(not(test))]
+        let workspace_id = screen.id;
 
         let mut new_workspace = Workspace::new(
             screen.bbox,

--- a/leftwm-core/src/handlers/screen_create_handler.rs
+++ b/leftwm-core/src/handlers/screen_create_handler.rs
@@ -19,7 +19,6 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             screen.bbox,
             self.state.layout_manager.new_layout(workspace_id),
             screen.max_window_width.or(self.state.max_window_width),
-            screen.output.clone(),
             workspace_id,
         );
         if self.state.workspaces.len() >= tag_len {

--- a/leftwm-core/src/handlers/screen_create_handler.rs
+++ b/leftwm-core/src/handlers/screen_create_handler.rs
@@ -12,14 +12,12 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
         let tag_index = self.state.workspaces.len();
         let tag_len = self.state.tags.len_normal();
 
-        // Only used in tests, where there are multiple screens being created by `Screen::default()` (id is 0 by default)
-        #[cfg(test)]
+        // Only used in tests, where there are multiple screens being created by `Screen::default()`
+        // The screen passed to this function should normally already have it's id given in the config serialization.
         let workspace_id = match screen.id {
-            0 => self.state.workspaces.last().map_or(0, |ws| ws.id) + 1,
-            other => other,
+            None => self.state.workspaces.last().map_or(0, |ws| ws.id) + 1,
+            Some(set_id) => set_id,
         };
-        #[cfg(not(test))]
-        let workspace_id = screen.id;
 
         let mut new_workspace = Workspace::new(
             screen.bbox,

--- a/leftwm-core/src/layouts.rs
+++ b/leftwm-core/src/layouts.rs
@@ -153,7 +153,6 @@ mod tests {
             },
             Layout::default(),
             None,
-            String::from("TEST"),
             0,
         );
         ws.margin = Margins::new(0);

--- a/leftwm-core/src/models/dto.rs
+++ b/leftwm-core/src/models/dto.rs
@@ -11,7 +11,6 @@ pub struct Viewport {
     pub x: i32,
     pub y: i32,
     pub layout: Layout,
-    pub output: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -42,7 +41,6 @@ pub struct DisplayWorkspace {
     pub w: u32,
     pub x: i32,
     pub y: i32,
-    pub output: String,
     pub layout: Layout,
     pub index: usize,
     pub tags: Vec<TagsForWorkspace>,
@@ -110,7 +108,6 @@ fn viewport_into_display_workspace(
         y: viewport.y,
         layout: viewport.layout,
         index: ws_index,
-        output: viewport.output.clone(),
     }
 }
 
@@ -147,7 +144,6 @@ impl From<&State> for ManagerState {
                 h: ws.xyhw.h() as u32,
                 w: ws.xyhw.w() as u32,
                 layout: ws.layout,
-                output: ws.output.clone(),
             });
         }
         let active_desktop = match state.focus_manager.workspace(&state.workspaces) {

--- a/leftwm-core/src/models/gutter.rs
+++ b/leftwm-core/src/models/gutter.rs
@@ -12,19 +12,13 @@ pub enum Side {
 pub struct Gutter {
     pub side: Side,
     pub value: i32,
-    pub output: Option<String>,
     pub id: Option<usize>,
 }
 
 impl Gutter {
     #[must_use]
-    pub const fn new(side: Side, value: i32, output: Option<String>, id: Option<usize>) -> Self {
-        Self {
-            side,
-            value,
-            output,
-            id,
-        }
+    pub const fn new(side: Side, value: i32, id: Option<usize>) -> Self {
+        Self { side, value, id }
     }
 }
 
@@ -33,7 +27,6 @@ impl Default for Gutter {
         Self {
             side: Side::Top,
             value: 0,
-            output: None,
             id: None,
         }
     }

--- a/leftwm-core/src/models/layout_manager.rs
+++ b/leftwm-core/src/models/layout_manager.rs
@@ -156,7 +156,6 @@ mod tests {
             },
             layout,
             None,
-            String::from("TEST"),
             id,
         )
     }

--- a/leftwm-core/src/models/screen.rs
+++ b/leftwm-core/src/models/screen.rs
@@ -8,7 +8,7 @@ use x11_dl::xlib;
 pub struct Screen {
     pub root: WindowHandle,
     pub output: String,
-    pub id: Option<WorkspaceId>,
+    pub id: WorkspaceId,
     #[serde(flatten)]
     pub bbox: BBox,
     pub max_window_width: Option<Size>,
@@ -25,13 +25,13 @@ pub struct BBox {
 
 impl Screen {
     #[must_use]
-    pub const fn new(bbox: BBox) -> Self {
+    pub const fn new(bbox: BBox, output: String, id: WorkspaceId) -> Self {
         Self {
             root: WindowHandle::MockHandle(0),
-            output: String::new(),
+            output,
             bbox,
             max_window_width: None,
-            id: None,
+            id,
         }
     }
 
@@ -135,7 +135,7 @@ impl Default for Screen {
         Self {
             root: WindowHandle::MockHandle(0),
             output: String::default(),
-            id: None,
+            id: 0,
             bbox: BBox {
                 height: 600,
                 width: 800,

--- a/leftwm-core/src/models/screen.rs
+++ b/leftwm-core/src/models/screen.rs
@@ -8,7 +8,7 @@ use x11_dl::xlib;
 pub struct Screen {
     pub root: WindowHandle,
     pub output: String,
-    pub id: WorkspaceId,
+    pub id: Option<WorkspaceId>,
     #[serde(flatten)]
     pub bbox: BBox,
     pub max_window_width: Option<Size>,
@@ -25,13 +25,13 @@ pub struct BBox {
 
 impl Screen {
     #[must_use]
-    pub const fn new(bbox: BBox, output: String, id: WorkspaceId) -> Self {
+    pub const fn new(bbox: BBox, output: String) -> Self {
         Self {
             root: WindowHandle::MockHandle(0),
             output,
             bbox,
             max_window_width: None,
-            id,
+            id: None,
         }
     }
 
@@ -135,7 +135,7 @@ impl Default for Screen {
         Self {
             root: WindowHandle::MockHandle(0),
             output: String::default(),
-            id: 0,
+            id: None,
             bbox: BBox {
                 height: 600,
                 width: 800,

--- a/leftwm-core/src/models/workspace.rs
+++ b/leftwm-core/src/models/workspace.rs
@@ -21,9 +21,7 @@ pub struct Workspace {
     pub xyhw: Xyhw,
     xyhw_avoided: Xyhw,
     pub max_window_width: Option<Size>,
-    /// Output (monitor) the workspace is linked to.
-    pub output: String,
-    /// ID of workspace on output. Starts with 1.
+    /// ID of workspace. Starts with 1.
     pub id: WorkspaceId,
 }
 
@@ -31,8 +29,7 @@ impl fmt::Debug for Workspace {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "Workspace {{ output: {:?}, id: {}, tags: {:?}, x: {}, y: {} }}",
-            self.output,
+            "Workspace {{ id: {}, tags: {:?}, x: {}, y: {} }}",
             self.id,
             self.tag,
             self.xyhw.x(),
@@ -43,19 +40,13 @@ impl fmt::Debug for Workspace {
 
 impl PartialEq for Workspace {
     fn eq(&self, other: &Self) -> bool {
-        self.output == other.output && self.id == other.id
+        self.id == other.id
     }
 }
 
 impl Workspace {
     #[must_use]
-    pub fn new(
-        bbox: BBox,
-        layout: Layout,
-        max_window_width: Option<Size>,
-        output: String,
-        id: usize,
-    ) -> Self {
+    pub fn new(bbox: BBox, layout: Layout, max_window_width: Option<Size>, id: usize) -> Self {
         Self {
             layout,
             main_width_percentage: layout.main_width(),
@@ -81,7 +72,6 @@ impl Workspace {
             }
             .into(),
             max_window_width,
-            output,
             id,
         }
     }
@@ -95,15 +85,11 @@ impl Workspace {
         config
             .get_list_of_gutters()
             .into_iter()
-            .filter(|gutter| {
-                gutter.output.is_none()
-                    || gutter.output == Some(self.output.clone())
-                        && (gutter.id.is_none() || gutter.id == Some(self.id))
-            })
+            .filter(|gutter| gutter.id.is_none() || gutter.id == Some(self.id))
             .fold(vec![], |mut acc, gutter| {
                 match acc.iter().enumerate().find(|(_i, g)| g.side == gutter.side) {
                     Some((i, x)) => {
-                        if x.output.is_none() {
+                        if x.id.is_none() {
                             acc[i] = gutter;
                         }
                     }
@@ -264,7 +250,6 @@ mod tests {
             },
             Layout::default(),
             None,
-            String::new(),
             0,
         );
         let w = Window::new(WindowHandle::MockHandle(1), None, None);
@@ -286,7 +271,6 @@ mod tests {
             },
             Layout::default(),
             None,
-            String::new(),
             0,
         );
         let tag = crate::models::Tag::new(TAG_ID, "test", Layout::default());

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -82,8 +82,7 @@ pub struct WindowHook {
     )]
     pub window_title: Option<Regex>,
     pub spawn_on_tag: Option<usize>,
-    pub spawn_on_workspace: Option<String>,
-    pub spawn_on_workspace_id: Option<usize>,
+    pub spawn_on_workspace: Option<usize>,
     pub spawn_floating: Option<bool>,
     pub spawn_sticky: Option<bool>,
     pub spawn_fullscreen: Option<bool>,
@@ -119,11 +118,11 @@ impl WindowHook {
             window.tag = Some(tag);
         }
         if self.spawn_on_workspace.is_some() {
-            if let Some(workspace) = state.workspaces.iter().find(|ws| {
-                &ws.output == self.spawn_on_workspace.as_ref().unwrap()
-                    && (self.spawn_on_workspace_id.is_none()
-                        || Some(ws.id) == self.spawn_on_workspace_id)
-            }) {
+            if let Some(workspace) = state
+                .workspaces
+                .iter()
+                .find(|ws| &ws.id == self.spawn_on_workspace.as_ref().unwrap())
+            {
                 if let Some(tag) = workspace.tag {
                     // In order to apply the correct margin multiplier we want to copy this value
                     // from any window already present on the target tag

--- a/leftwm/src/theme_setting.rs
+++ b/leftwm/src/theme_setting.rs
@@ -134,7 +134,6 @@ value = 0
                 gutter: Some(vec![Gutter {
                     side: Side::Top,
                     value: 0,
-                    output: None,
                     id: None
                 }]),
                 default_border_color: Some("#222222".to_string()),
@@ -182,7 +181,6 @@ value = 0
                 gutter: Some(vec![Gutter {
                     side: Side::Top,
                     value: 0,
-                    output: None,
                     id: None,
                 }]),
                 default_border_color: Some("#222222".to_string()),


### PR DESCRIPTION
# Description

Remove output field from the internal `workspace` struct. Id management has been reworked to be done internally (for now; **TODO** introduce old behavior), ids are assigned in the order that workspaces are being created, beginning at 1.

Note: If we make the output field optional and the id field behave like normal (auto-derived if not given), we will be backwards-compatible with before-https://github.com/leftwm/leftwm/pull/848

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [x] This change requires a documentation update

## Updated user documentation:

Remove most mentions of outputs, they are now only used as necessary field in the workspaces config.

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [x] Manual page has been updated accordingly
  (no change needed)
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
